### PR TITLE
config : allow usdz file regardless of name of file

### DIFF
--- a/libs/server/ServerFileHandling.ts
+++ b/libs/server/ServerFileHandling.ts
@@ -142,7 +142,7 @@ export async function getModelFromDir(dirPath: string): Promise<OptionalModel> {
       if ("thumbnail.png" === relativeFileName) {
         model.thumbnail = relativeFileName;
       }
-      if ("scene.usdz" === relativeFileName) {
+      if ([".usdz"].includes(extname(relativeFileName))) {
         model.modelUsdz = relativeFileName;
         model.usdzSize = BigInt(statSync(file).size);
       }


### PR DESCRIPTION
#97 Now usdz file in zip file will be uploaded regardless of the name of file.